### PR TITLE
[hotfix] Make GetEvents::endTime exclusive

### DIFF
--- a/src/event.service.ts
+++ b/src/event.service.ts
@@ -53,8 +53,7 @@ export class EventService {
       startDate.setHours(startDate.getHours() + 1);
       startBucket = this.getBucket(startDate);
     }
-    buckets.push(endBucket);
-
+    
     const customerData = this.database.get(customerId);
     
     buckets.forEach((bucket) => {


### PR DESCRIPTION
EndTime should be **exclusive**, i.e. if endTime == "2021-03-02T18:00:00Z", the last bucket to return should be:

2021-3-2-17

**Postman Request:**

```
GET localhost:3000/events?customerId=1abb42414607955dbf6088b99f837d8f&startTime=1614686400000&endTime=1614708000000
```

**Response (Before):**
```
{
    "events": {
        "2021-3-2-14": 2,
        "2021-3-2-15": 14,
        "2021-3-2-16": 8,
        "2021-3-2-17": 15,
        "2021-3-2-18": 11
    }
}
```

**Response (Now):**

```
{
    "events": {
        "2021-3-2-14": 2,
        "2021-3-2-15": 14,
        "2021-3-2-16": 8,
        "2021-3-2-17": 15
    }
}

```